### PR TITLE
Fix makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,5 +4,5 @@ all: clean
 	idris -o igrep Main.idr -p effects -p lightyear --typeintype
 
 clean:
-	rm igrep
-	rm *.ibc
+	-rm igrep
+	-rm *.ibc


### PR DESCRIPTION
Sem esta modificação, o comando `make` irá falhar caso um arquivo a ser apagado pelo `rm` ainda não exista.
